### PR TITLE
feat: Phase 1 completing - basic MD File Reading & Dual-Pane Layout

### DIFF
--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -1,0 +1,19 @@
+use std::fs;
+use std::path::Path;
+
+/// Read a local Markdown file and return its content as a String.
+/// Returns an error message string if the file cannot be read.
+#[tauri::command]
+pub fn read_md_file(path: String) -> Result<String, String> {
+    let p = Path::new(&path);
+
+    if !p.exists() {
+        return Err(format!("File not found: {}", path));
+    }
+
+    if p.extension().and_then(|e| e.to_str()) != Some("md") {
+        return Err(format!("Not a Markdown file: {}", path));
+    }
+
+    fs::read_to_string(p).map_err(|e| format!("Failed to read file: {}", e))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod file;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,12 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
+mod commands;
+
+use commands::file::read_md_file;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![read_md_file])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,116 +1,228 @@
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafb);
-}
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color: #0f0f0f;
-  background-color: #f6f6f6;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
-.container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
-}
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
-  outline: none;
-}
-
-#greet-input {
-  margin-right: 5px;
+  --sidebar-width: 280px;
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8fafc;
+  --bg-hover: #e2e8f0;
+  --text-primary: #1e293b;
+  --text-secondary: #64748b;
+  --border-color: #e2e8f0;
+  --accent-color: #3b82f6;
+  --accent-hover: #2563eb;
+  --error-bg: #fef2f2;
+  --error-text: #ef4444;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-hover: #334155;
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    --border-color: #334155;
+    --accent-color: #3b82f6;
+    --accent-hover: #60a5fa;
+    --error-bg: #450a0a;
+    --error-text: #f87171;
   }
+}
 
-  a:hover {
-    color: #24c8db;
-  }
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  overflow: hidden; /* Prevent body scroll, handle scroll in MainContent */
+}
 
-  input,
-  button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
-  }
-  button:active {
-    background-color: #0f0f0f69;
-  }
+/* Layout */
+.app-layout {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* Sidebar */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background-color: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-header {
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-icon {
+  font-size: 1.5rem;
+  margin-right: 8px;
+}
+
+.sidebar-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+
+.sidebar-section {
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.sidebar-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  margin-bottom: 12px;
+  box-sizing: border-box;
+}
+
+.sidebar-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.sidebar-btn {
+  width: 100%;
+  padding: 8px 16px;
+  background-color: var(--accent-color);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.sidebar-btn:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}
+
+.sidebar-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sidebar-toc-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.sidebar-toc-hint {
+  font-size: 0.875rem;
+  margin: 0 0 4px 0;
+}
+
+.sidebar-toc-sub {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  margin: 0;
+}
+
+/* Main Content */
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  position: relative;
+  background-color: var(--bg-primary);
+}
+
+.main-filepath {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+  padding: 12px 24px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  z-index: 10;
+  opacity: 0.95;
+  backdrop-filter: blur(8px);
+}
+
+.main-pre {
+  margin: 0;
+  padding: 24px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.main-error {
+  margin: 24px;
+  padding: 16px;
+  background-color: var(--error-bg);
+  border-left: 4px solid var(--error-text);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.main-error-icon {
+  font-size: 1.5rem;
+  margin-right: 12px;
+}
+
+.main-error-msg {
+  color: var(--error-text);
+  margin: 0;
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.main-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-secondary);
+}
+
+.main-empty-icon {
+  font-size: 3rem;
+  margin: 0 0 16px 0;
+  opacity: 0.5;
+}
+
+.main-empty-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+
+.main-empty-sub {
+  font-size: 0.875rem;
+  margin: 0;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,50 +1,41 @@
 import { useState } from "react";
-import reactLogo from "./assets/react.svg";
 import { invoke } from "@tauri-apps/api/core";
+import { Sidebar } from "./components/Sidebar";
+import { MainContent } from "./components/MainContent";
 import "./App.css";
 
 function App() {
-  const [greetMsg, setGreetMsg] = useState("");
-  const [name, setName] = useState("");
+  const [filePath, setFilePath] = useState("");
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-  async function greet() {
-    // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-    setGreetMsg(await invoke("greet", { name }));
+  async function loadFile() {
+    if (!filePath.trim()) return;
+    setIsLoading(true);
+    setError(null);
+    setContent(null);
+
+    try {
+      const text = await invoke<string>("read_md_file", { path: filePath.trim() });
+      setContent(text);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (
-    <main className="container">
-      <h1>Welcome to Tauri + React</h1>
-
-      <div className="row">
-        <a href="https://vite.dev" target="_blank">
-          <img src="/vite.svg" className="logo vite" alt="Vite logo" />
-        </a>
-        <a href="https://tauri.app" target="_blank">
-          <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <p>Click on the Tauri, Vite, and React logos to learn more.</p>
-
-      <form
-        className="row"
-        onSubmit={(e) => {
-          e.preventDefault();
-          greet();
-        }}
-      >
-        <input
-          id="greet-input"
-          onChange={(e) => setName(e.currentTarget.value)}
-          placeholder="Enter a name..."
-        />
-        <button type="submit">Greet</button>
-      </form>
-      <p>{greetMsg}</p>
-    </main>
+    <div className="app-layout">
+      <Sidebar
+        filePath={filePath}
+        onFilePathChange={setFilePath}
+        onLoad={loadFile}
+        isLoading={isLoading}
+      />
+      <MainContent content={content} error={error} filePath={filePath} />
+    </div>
   );
 }
 

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -1,0 +1,37 @@
+interface MainContentProps {
+  content: string | null;
+  error: string | null;
+  filePath: string;
+}
+
+export function MainContent({ content, error, filePath }: MainContentProps) {
+  if (error) {
+    return (
+      <main className="main-content">
+        <div className="main-error">
+          <span className="main-error-icon">⚠️</span>
+          <p className="main-error-msg">{error}</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <main className="main-content">
+        <div className="main-empty">
+          <p className="main-empty-icon">📝</p>
+          <p className="main-empty-title">No file loaded</p>
+          <p className="main-empty-sub">Enter a path in the sidebar and press Open.</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="main-content">
+      <div className="main-filepath">{filePath}</div>
+      <pre className="main-pre">{content}</pre>
+    </main>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,45 @@
+interface SidebarProps {
+  filePath: string;
+  onFilePathChange: (path: string) => void;
+  onLoad: () => void;
+  isLoading: boolean;
+}
+
+export function Sidebar({ filePath, onFilePathChange, onLoad, isLoading }: SidebarProps) {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-header">
+        <span className="sidebar-icon">📄</span>
+        <h2 className="sidebar-title">mdlv</h2>
+      </div>
+
+      <div className="sidebar-section">
+        <label className="sidebar-label" htmlFor="file-path-input">
+          File Path
+        </label>
+        <input
+          id="file-path-input"
+          className="sidebar-input"
+          type="text"
+          value={filePath}
+          onChange={(e) => onFilePathChange(e.currentTarget.value)}
+          placeholder="/path/to/file.md"
+          spellCheck={false}
+        />
+        <button
+          id="load-file-btn"
+          className="sidebar-btn"
+          onClick={onLoad}
+          disabled={isLoading || !filePath.trim()}
+        >
+          {isLoading ? "Loading…" : "Open"}
+        </button>
+      </div>
+
+      <div className="sidebar-toc-placeholder">
+        <p className="sidebar-toc-hint">TOC will appear here</p>
+        <p className="sidebar-toc-sub">— Phase 2 —</p>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## 概要
Issue #3 の内容を実装し、Phase 1 を完了。

## 変更内容
- Rust IPC コマンド `read_md_file(path: String) -> Result<String>` の実装
  - 存在しないファイルや非MDファイルのハンドリング
- React コンポーネント `Sidebar` および `MainContent` の実装
- Tailwind CSS / App.css でのデュアルペインレイアウトの構築
- App.tsx にて状態管理 (filePath, content, error, isLoading) を実装

Closes #3